### PR TITLE
properly treat utf8 chars in password

### DIFF
--- a/lib/SHA256.js
+++ b/lib/SHA256.js
@@ -85,32 +85,6 @@ function SHA256(s){
 		return bin;
 	}
  
-	function Utf8Encode(string) {
-		string = string.replace(/\r\n/g,"\n");
-		var utftext = "";
- 
-		for (var n = 0; n < string.length; n++) {
- 
-			var c = string.charCodeAt(n);
- 
-			if (c < 128) {
-				utftext += String.fromCharCode(c);
-			}
-			else if((c > 127) && (c < 2048)) {
-				utftext += String.fromCharCode((c >> 6) | 192);
-				utftext += String.fromCharCode((c & 63) | 128);
-			}
-			else {
-				utftext += String.fromCharCode((c >> 12) | 224);
-				utftext += String.fromCharCode(((c >> 6) & 63) | 128);
-				utftext += String.fromCharCode((c & 63) | 128);
-			}
- 
-		}
- 
-		return utftext;
-	}
- 
 	function binb2hex (binarray) {
 		var hex_tab = hexcase ? "0123456789ABCDEF" : "0123456789abcdef";
 		var str = "";
@@ -120,7 +94,7 @@ function SHA256(s){
 		}
 		return str;
 	}
- 
+
 	return binb2hex(core_sha256(str2binb(s), s.length * chrsz));
  
 }

--- a/spec/calculate_spec.js
+++ b/spec/calculate_spec.js
@@ -32,8 +32,21 @@ describe("Calculate", function() {
   });
 
   it("calculates the right verifier", function() {
-    x = calculate.X(compare.username, compare.password, compare.salt)
-    expect(calculate.V(x)).toBe(compare.v);
+    calculate_and_compare_verifier(compare);
   });
-  
+
+  it("calculates the right verifier with umlauts", function() {
+    with_umlauts = {
+      username: "test_joakcq", 
+      password: "fs5uofäöìfvqynn",
+      salt: "eec1ff4c",
+      v: "551e82de8d61a6575a3da7fbede61f6f38164ed52eb64db031c1ec2316b474745d3ff24408bfcca3c50fc53283f2f975feebf1564d197051c834a56bf8bd804f3696d81e579915141f306242f133db210cbd11385afff01c355ca8446d92d8a54ff147ebb0e1cd3d5c78750a0488f1453473e9449a946c7c9298c167cc5adafc"
+    }
+    calculate_and_compare_verifier(with_umlauts);
+  });
+
+  function calculate_and_compare_verifier(values) {
+    x = calculate.X(values.username, values.password, values.salt)
+    expect(calculate.V(x)).toBe(values.v);
+  }
 });

--- a/src/srp_calculate.js
+++ b/src/srp_calculate.js
@@ -50,13 +50,12 @@ srp.Calculate = function() {
   };
 
   this.hashHex = function(hexString) {
-    return this.hash(hex2a(hexString));
+    return SHA256(hex2a(hexString));
   };
 
   this.hash = function(string) {
-    return SHA256(string);
+    return SHA256(utf8Encode(string));
   };
-
 
   this.isInvalidEphemeral = function(a) {
     return (g.modPow(a, N) == 0);
@@ -116,5 +115,27 @@ srp.Calculate = function() {
       str += (xor.length == 1) ? ("0" + xor) : xor
     }
     return str;
+  }
+  
+  function utf8Encode(string) {
+    string = string.replace(/\r\n/g,"\n");
+    var utftext = "";
+
+    for (var n = 0; n < string.length; n++) {
+      var c = string.charCodeAt(n);
+      if (c < 128) {
+        utftext += String.fromCharCode(c);
+      }
+      else if((c > 127) && (c < 2048)) {
+        utftext += String.fromCharCode((c >> 6) | 192);
+        utftext += String.fromCharCode((c & 63) | 128);
+      }
+      else {
+        utftext += String.fromCharCode((c >> 12) | 224);
+        utftext += String.fromCharCode(((c >> 6) & 63) | 128);
+        utftext += String.fromCharCode((c & 63) | 128);
+      }
+    }
+    return utftext;
   }
 };


### PR DESCRIPTION
utf-8 encoding used to be bundled with the SHA256 library. However we only want to utf8 encode strings that are actual user input. We do not want to encode the bytearrays that are used when hashing the hex values calculated during for SRP.

So I separated the utf-8 encoding and the sha256 hashing.
