### PR TITLE
Allow extra signup params from account

### DIFF
--- a/spec/session_spec.js
+++ b/spec/session_spec.js
@@ -72,4 +72,37 @@ describe("Session", function() {
     session = new srp.Session(account);
     expect(session.login()).toBe(compare.username);
   });
+
+  it('calculates secure user parameters for signup', function() {
+    var compare = short_b;
+    account = new srp.Account(compare.username, compare.password);
+    session = new srp.Session(account);
+
+    var signupParams = session.signup();
+
+    expect(Object.keys(signupParams)).toEqual(['login', 'password_salt', 'password_verifier']);
+  });
+
+  it('calculates secure user parameters for update', function() {
+    var compare = short_b;
+    account = new srp.Account(compare.username, compare.password);
+    session = new srp.Session(account);
+
+    var signupParams = session.update();
+
+    expect(Object.keys(signupParams)).toEqual(['login', 'password_salt', 'password_verifier']);
+  });
+
+  it("grabs extra signup parameters from account", function() {
+    account = jasmine.createSpyObj('account', ['login', 'password']);
+    account.loginParams = function() {
+      return {
+        "extraParam": "foobar"
+      }
+    }
+    session = new srp.Session(account);
+
+    expect(session.signup().extraParam).toBe("foobar");
+  });
+
 });

--- a/src/jqueryRest.js
+++ b/src/jqueryRest.js
@@ -11,7 +11,7 @@ srp.remote = (function(){
         url: "/1/users/" + session.id() + ".json",
         type: 'PUT',
         headers: { Authorization: 'Token token="' + token + '"' },
-        data: {user: session.signup() }
+        data: {user: session.update() }
       });
     }
 

--- a/src/srp_session.js
+++ b/src/srp_session.js
@@ -22,7 +22,7 @@ srp.Session = function(account, calculate) {
     return A;
   };
 
-  this.signup = function() {
+  this.update = function() {
     var salt = calculate.randomSalt();
     var x = calculate.X(account.login(), account.password(), salt);
     return {
@@ -30,6 +30,19 @@ srp.Session = function(account, calculate) {
       password_salt: salt,
       password_verifier: calculate.V(x)
     };
+  }
+
+  this.signup = function() {
+    var loginParams = this.update();
+
+    if (account.loginParams) {
+      var extraParams = account.loginParams();
+      for (var attr in extraParams) {
+        loginParams[attr] = extraParams[attr];
+      }
+    }
+
+    return loginParams;
   };
 
   this.handshake = function() {


### PR DESCRIPTION
For the feature/invite-codes in leap_web, we need to be able to pass an
extra parameter (the invite code) from the signup form to the server[1].
This creates a circular dependency between leap_web and srp.js, thus
defying idea of separating the srp.js from the app.

This change allows the consumer of SRP to specify a custom
implementation of Account that returns arbitrary `loginParams`, and
Session will pass them on so that they become part of the XHR.

Also, splits session.signup into signup and update to restrict extra params
to signup only

[1]: https://github.com/Alster-Hamburgers/srp_js/commit/26b6d11f1eeae2c0f1b47ce2230d5e15684d6483